### PR TITLE
Rewrite createUniqueOperationId to produce usable code

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -359,6 +359,16 @@ var routeHelper = module.exports = {
 };
 
 function createUniqueOperationId(methodName, verb, path, operationIdRegistry) {
+  // The algorithm used below to generate unique operation IDs causes
+  // invalid code to be generated with swagger-codegen.
+  // We are overriding the ID generation to simply be the method name.
+  // Technically this breaks Swagger Spec 2.0 compability, but has the
+  // Good Side Effect of producing usable code with swagger-codegen
+
+  var id = methodName.substr(methodName.lastIndexOf('.'));
+  return id;
+
+
   // [bajtos] We used to remove leading model name from the operation
   // name for Swagger Spec 1.2. Swagger Spec 2.0 requires
   // operation ids to be unique, thus we have to include the model name.


### PR DESCRIPTION
### Description
Ignores all the work in generateUniqueOperationID to instead just return the method name. This has the Good Side Effect of generating usable code when used with swagger-codegen.